### PR TITLE
Fix Vue component creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ npm run build
 ```js
 import myCmp from 'dist/my-cmp';
 
-Vue.component('my-cmp', myCmp);
+Vue.component('my-cmp', myCmp.default);
 ```
 
 #### UMD

--- a/template/README.md
+++ b/template/README.md
@@ -24,7 +24,7 @@
 import {{ camelcase name }} from '{{ name }}';
 import '{{ name }}/dist/{{ name }}.min.css';
 
-Vue.component('{{ name }}', {{ camelcase name }});
+Vue.component('{{ name }}', {{ camelcase name }}.default);
 ```
 
 ```html


### PR DESCRIPTION
When importing the component in a Vue.js, the component is on the `default` property (same as the UMD method).

Related issue: https://github.com/InCuca/vue-standalone-component/issues/9